### PR TITLE
index.html css/layout refactor

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -459,7 +459,7 @@ body {
 }
 
 #ice40-div {
-  max-width: 500px;
+  flex-basis: 500px;
   padding-right: 20px;
 }
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -31,18 +31,12 @@
 
 .unselectable {
   /* https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting */
-  -webkit-touch-callout: none;
-  /* iOS Safari */
-  -webkit-user-select: none;
-  /* Safari */
-  -khtml-user-select: none;
-  /* Konqueror HTML */
-  -moz-user-select: none;
-  /* Old versions of Firefox */
-  -ms-user-select: none;
-  /* Internet Explorer/Edge */
-  user-select: none;
-  /* Non-prefixed version, currently
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Old versions of Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* Non-prefixed version, currently
                       supported by Chrome, Edge, Opera and Firefox */
 }
 
@@ -411,8 +405,7 @@ body {
   height: auto;
   display: flex;
   flex-direction: row;
-  align-items: center"
-
+  align-items: center;
 }
 
 .download-button {
@@ -441,7 +434,7 @@ body {
 }
 
 #status-text {
-  font-size: calc(0.35rem + 0.2vh + 0.8vw);
+  font-size: calc(0.35rem + 0.2vh + 0.7vw);
 }
 
 .desc.display-4.text-center.text-muted {
@@ -449,7 +442,7 @@ body {
   border-right: 1px solid gray;
   padding-left: 2.25vw;
   padding-right: 2.25vw;
-  font-size: calc(0.35rem + 0.2vh + 0.8vw);
+  font-size: calc(0.35rem + 0.2vh + 0.7vw);
 }
 
 #desctext {
@@ -460,16 +453,14 @@ body {
 }
 
 #simview {
-  text-align: center;
   align-items: center;
-  width: 100%;
-  margin: 0;
-  padding-right: 0px;
+  margin-left: 5vw;
+  padding-right: 3vw;
 }
 
 #ice40-div {
   max-width: 500px;
-  padding-right: 1px;
+  padding-right: 20px;
 }
 
 #editor-workspace {
@@ -489,12 +480,11 @@ body {
   align-items: center;
   justify-content: center;
   margin-right: 10px;
+  margin-left: 10px;
   margin-bottom: 4px;
   font-size: calc(0.9rem+ 0.2vw);
   flex: 1;
 }
-
-
 
 .row.btn-row {
   margin-top: 10px;
@@ -503,7 +493,8 @@ body {
   flex-wrap: nowrap;
   justify-content: space-evenly;
   align-items: center;
-
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .lowerbtn {
@@ -519,14 +510,19 @@ body {
   font-size: calc(0.8rem + 0.2vw);
 }
 
+.col.align-self-center {
+	padding-left: 0px;
+	padding-right: 0px;
+}
+
 option {
   font-family: 'Lato', sans-serif;
   font-weight: 300;
   font-size: calc(0.75vw + 0.5vh);
 }
 
+/***************************************************************/
 /* For firefox */
-
 /***************************************************************/
 
 .ace_scrollbar, .help_scrollbar {
@@ -540,9 +536,7 @@ option {
 }
 
 /***************************************************************/
-
 /* For chrome */
-
 /***************************************************************/
 
 .ace_scrollbar-v::-webkit-scrollbar, .help_scrollbar-v::-webkit-scrollbar {
@@ -550,13 +544,11 @@ option {
 }
 
 /* Track */
-
 .ace_scrollbar::-webkit-scrollbar-track, .help_scrollbar::-webkit-scrollbar-track {
   background: var(--scrollbar-track);
 }
 
 /* Handle */
-
 .ace_scrollbar::-webkit-scrollbar-thumb, .help_scrollbar::-webkit-scrollbar-thumb {
   width: 6px;
   background: var(--scrollbar-thumb);
@@ -564,7 +556,6 @@ option {
 }
 
 /* Handle on hover */
-
 .ace_scrollbar::-webkit-scrollbar-thumb:hover, .help_scrollbar::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
 }
@@ -615,23 +606,17 @@ select, [name="project_list"] {
 }
 
 .overlay {
-  position: fixed;
-  /* Sit on top of the page content */
-  display: none;
-  /* Hidden by default */
-  width: 100%;
-  /* Full width (cover the whole page) */
-  height: 100%;
-  /* Full height (cover the whole page) */
+  position: fixed; /* Sit on top of the page content */
+  display: none; /* Hidden by default */
+  width: 100%; /* Full width (cover the whole page) */
+  height: 100%; /* Full height (cover the whole page) */
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
   opacity: 0;
-  background-color: rgba(0, 30, 50, 0.6);
-  /* Black background with opacity */
-  z-index: 2;
-  /* Specify a stack order in case you're using a different order for other elements */
+  background-color: rgba(0, 30, 50, 0.6); /* Black background with opacity */
+  z-index: 2; /* Specify a stack order in case you're using a different order for other elements */
   transition: all 0.3s;
 }
 
@@ -675,7 +660,6 @@ select, [name="project_list"] {
 }
 
 /* Tutorial needs to be able to move around */
-
 #overlay_7 {
   width: 45%;
   height: 60%;
@@ -1033,10 +1017,8 @@ input[name="filedir"]:checked+label {
 }
 
 /* https://stackoverflow.com/questions/20435166/contenteditable-not-working-in-safari-but-works-in-chrome */
-
 /* This allows the user to edit the tab/workspace names on Safari, because as usual 
 Apple screws everything up for everyone who tries to develop on its platforms */
-
 [contenteditable] {
   -webkit-user-select: text;
   user-select: text;
@@ -1074,13 +1056,11 @@ Apple screws everything up for everyone who tries to develop on its platforms */
 }
 
 /* sorry not sorry */
-
 #nevergonnagiveyouup:hover {
   filter: brightness(1.5);
 }
 
 /* frostyfinder! */
-
 .findallresult {
   width: 90%;
   padding: 3%;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -401,7 +401,7 @@ body {
 }
 
 .display-4.text-center.text-muted.title {
-  font-size: calc(0.5rem + 1.3vw + 0.5vh);
+  font-size: calc(0.5rem + 0.8vw + 0.4vh);
   width: auto;
   margin: 0 10vw 0 10vw
 }
@@ -417,7 +417,7 @@ body {
 
 .download-button {
   cursor: pointer;
-  font-size: calc(0.35rem + 0.8vw + 0.25vh);
+  font-size: calc(0.35rem + 0.7vw + 0.15vh);
   margin: 0;
 }
 
@@ -473,13 +473,15 @@ body {
 }
 
 #editor-workspace {
-  min-width: 60%;
+  min-width: 400px;
+  max-width: 100%;
   flex: 1;
-  height: 100%;
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding-right: 10px
+  padding-right: 10px;
+  margin-bottom: 20px;
+  margin-top: 10px;
 }
 
 .btn.btn-bevel.btn-filter {
@@ -1057,12 +1059,14 @@ Apple screws everything up for everyone who tries to develop on its platforms */
 }
 
 #resize-editor {
-  height: 33%;
-  width: 1%;
+  height: 200px;
+  width: 10px;
   cursor: w-resize;
   background-color: transparent;
   border-left: 3px solid var(--display-4-color);
   transition: border 0.2s;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 
 #resize-editor:hover {

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -31,12 +31,18 @@
 
 .unselectable {
   /* https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting */
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -khtml-user-select: none; /* Konqueror HTML */
-  -moz-user-select: none; /* Old versions of Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently
+  -webkit-touch-callout: none;
+  /* iOS Safari */
+  -webkit-user-select: none;
+  /* Safari */
+  -khtml-user-select: none;
+  /* Konqueror HTML */
+  -moz-user-select: none;
+  /* Old versions of Firefox */
+  -ms-user-select: none;
+  /* Internet Explorer/Edge */
+  user-select: none;
+  /* Non-prefixed version, currently
                       supported by Chrome, Edge, Opera and Firefox */
 }
 
@@ -56,6 +62,7 @@
   font-size: calc(0.75vw + 0.25vh);
   transition: all 0.5s;
 }
+
 #logout:hover {
   background-color: var(--logout-hover);
 }
@@ -105,7 +112,6 @@
   transition: all 0.5s;
 }
 
-
 #autocompleteOuter {
   fill: var(--autocomplete-outer-fill);
 }
@@ -129,7 +135,6 @@
 #autoTerminalButtonOuter {
   fill: var(--autoterminal-outer-fill);
 }
-
 
 #autocompleteInner {
   fill: var(--autocomplete-inner-fill);
@@ -168,9 +173,9 @@
 }
 
 .ace-line-error {
-  position:absolute;
-  background:var(--ace-line-error-color);
-  z-index:20
+  position: absolute;
+  background: var(--ace-line-error-color);
+  z-index: 20
 }
 
 #outwego, #nevergonnagiveyouup {
@@ -197,7 +202,8 @@
   display: flex;
   flex-direction: row;
   overflow-x: auto;
-}  
+}
+
 .editor-tab, .editor-tab-workspace {
   width: auto;
   height: 4vh;
@@ -211,67 +217,306 @@
   cursor: pointer;
   transition: background-color 0.3s;
 }
+
 .editor-tab-workspace {
   min-width: 6vw;
   align-items: center;
   justify-content: center;
 }
+
 .editor-tab:not(#editor-tab-add):hover, .editor-tab-workspace:not(#editor-tab-workspace-add):hover {
   background: var(--etw-bg-hover);
 }
+
 #editor-tab-workspace-add {
   min-width: 2.5vw;
 }
+
 .editor-tab-workspace:first-child {
   border-radius: 5px 0 0 0;
 }
+
 .editor-tab-workspace:last-child {
   border-radius: 0 5px 0 0;
 }
+
 .editor-tab {
   border-radius: 0;
 }
+
 .tab-label-workspace, .tab-label {
   color: var(--display-4-color);
   cursor: pointer;
   display: flex;
   align-items: center;
   height: 100%;
-  font-size: calc(0.70vw + 0.20vh);
+  font-size: calc(0.8rem + 0.1vw + 0.05vh);
 }
+
 /* .tab-label:hover {
   background-color: var(--editor-tab-bg-hover);
 } */
+
 .tab-close, .wksp-tab-close {
   height: auto;
   margin: 0 0.5em 0 1em;
   width: 0.45vw!important;
   color: var(--display-4-color);
 }
+
 .tab-close:hover, .wksp-tab-close:hover {
   filter: opacity(0.5);
 }
+
 #wksp-tab-add {
   justify-content: center;
   align-items: center;
   width: 100%;
   margin: 0;
 }
+
 #tab-add {
   cursor: pointer;
   margin-right: 0;
 }
+
 #tab-add:hover {
   background-color: inherit;
 }
+
 .btn {
   cursor: pointer;
 }
 
 body {
   overflow-x: hidden;
-  background-color: var(--document-body-bg);
+  background-color: var(--navbar-upper-bg);
+  height: 100vh;
 }
+
+.findall {
+  width: 400px;
+  height: 500px;
+  position: absolute;
+  top: 25vh;
+  left: 25vw;
+  z-index: 100;
+  display: none;
+  opacity: 0;
+  transition: opacity 0.3s ease 0s;
+  background: rgba(255, 255, 255, 0.7) none repeat scroll 0% 0%;
+  border: 2px solid var(--display-4-color);
+  border-radius: 5px;
+}
+
+.findalltop {
+  width: 100%;
+  height: 2.5%;
+  background: #fff
+}
+
+.findallbkgd {
+  width: 100%;
+  height: 95%;
+  filter: blur(10px);
+  z-index: 99;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.findallbody {
+  width: 100%;
+  height: 95%;
+  filter: blur(0px);
+  position: absolute;
+  top: 2.5%;
+  left: 0;
+  z-index: 101;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  padding-top: 20px;
+  justify-content: flex-start;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: scroll
+}
+
+.findallwindow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 95%;
+  height: 10%;
+}
+
+.fa.fa-search {
+  margin-right: 15px;
+  font-size: 1rem;
+}
+
+#findallsearch {
+  width: 85%;
+  font-family: Open Sans;
+  background: transparent;
+  border: 1px solid #888;
+  border-radius: 5px;
+  padding-left: 10px;
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+#findallstatus {
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  width: 90%;
+  margin-top: 15px;
+  margin-bottom: 5px;
+}
+
+#overlay_top {
+  background-color: var(--navbar-upper-bg);
+}
+
+#mainview {
+  width: 100%;
+  height: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  transition: filter 0.75s
+}
+
+#header-flex {
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-evenly;
+  flex-wrap: wrap;
+}
+
+#header-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+.display-4.text-center.text-muted.title {
+  font-size: calc(0.5rem + 1.3vw + 0.5vh);
+  width: auto;
+  margin: 0 10vw 0 10vw
+}
+
+.download-div {
+  width: 10%;
+  height: auto;
+  display: flex;
+  flex-direction: row;
+  align-items: center"
+
+}
+
+.download-button {
+  cursor: pointer;
+  font-size: calc(0.35rem + 0.8vw + 0.25vh);
+  margin: 0;
+}
+
+#status-navbar {
+  vertical-align: middle;
+  padding: 0px!important;
+  background-color: #eaeaea;
+}
+
+.d-flex.justify-content-center {
+  width: 100%;
+  height: 100%;
+  padding-top: 1.25vh;
+  padding-bottom: 0.75vh;
+}
+
+.row.justify-content-center {
+  vertical-align: middle;
+  margin-left: 5vw;
+  padding-right: 3vw;
+}
+
+#status-text {
+  font-size: calc(0.35rem + 0.2vh + 0.8vw);
+}
+
+.desc.display-4.text-center.text-muted {
+  cursor: pointer;
+  border-right: 1px solid gray;
+  padding-left: 2.25vw;
+  padding-right: 2.25vw;
+  font-size: calc(0.35rem + 0.2vh + 0.8vw);
+}
+
+#desctext {
+  padding-top: 2vh;
+  padding-left: 20vw;
+  padding-right: 20vw;
+  font-size: calc(0.2rem + 0.3vh + 0.78vw);
+}
+
+#simview {
+  text-align: center;
+  align-items: center;
+  width: 100%;
+  margin: 0;
+  padding-right: 0px;
+}
+
+#ice40-div {
+  max-width: 500px;
+  padding-right: 1px;
+}
+
+#editor-workspace {
+  min-width: 60%;
+  flex: 1;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding-right: 10px
+}
+
+.btn.btn-bevel.btn-filter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 10px;
+  margin-bottom: 4px;
+  font-size: calc(0.9rem+ 0.2vw);
+  flex: 1;
+}
+
+
+
+.row.btn-row {
+  margin-top: 10px;
+  font-size: 32px;
+  width: 100%;
+  flex-wrap: nowrap;
+  justify-content: space-evenly;
+  align-items: center;
+
+}
+
+.lowerbtn {
+  color: var(--display-4-color); 
+  border: 1px solid var(--display-4-color); 
+  width: 45%; 
+  margin-right: 15px; 
+  margin-bottom: 6px; 
+  white-space: nowrap;
+  display: flex;
+  justify-content: center;
+  align-items: center;  
+  font-size: calc(0.8rem + 0.2vw);
+}
+
 option {
   font-family: 'Lato', sans-serif;
   font-weight: 300;
@@ -279,7 +524,9 @@ option {
 }
 
 /* For firefox */
+
 /***************************************************************/
+
 .ace_scrollbar, .help_scrollbar {
   scrollbar-color: var(--scrollbar-color);
   scroll-behavior: auto;
@@ -293,6 +540,7 @@ option {
 /***************************************************************/
 
 /* For chrome */
+
 /***************************************************************/
 
 .ace_scrollbar-v::-webkit-scrollbar, .help_scrollbar-v::-webkit-scrollbar {
@@ -300,11 +548,13 @@ option {
 }
 
 /* Track */
+
 .ace_scrollbar::-webkit-scrollbar-track, .help_scrollbar::-webkit-scrollbar-track {
   background: var(--scrollbar-track);
 }
 
 /* Handle */
+
 .ace_scrollbar::-webkit-scrollbar-thumb, .help_scrollbar::-webkit-scrollbar-thumb {
   width: 6px;
   background: var(--scrollbar-thumb);
@@ -312,6 +562,7 @@ option {
 }
 
 /* Handle on hover */
+
 .ace_scrollbar::-webkit-scrollbar-thumb:hover, .help_scrollbar::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
 }
@@ -334,16 +585,19 @@ select, [name="project_list"] {
   border-color: var(--btn-info-border);
   color: var(--btn-info-color);
 }
+
 .btn-primary, .btn-primary:hover {
   background-color: var(--btn-primary-bg);
   border-color: var(--btn-primary-border);
   color: var(--btn-primary-color);
 }
+
 .btn-dark, .btn-dark:hover {
   background-color: var(--btn-dark-bg);
   border-color: var(--btn-dark-border);
   color: var(--btn-dark-color);
 }
+
 .btn-danger, .btn-danger:hover {
   background-color: var(--btn-danger-bg);
   border-color: var(--btn-danger-border);
@@ -359,17 +613,23 @@ select, [name="project_list"] {
 }
 
 .overlay {
-  position: fixed; /* Sit on top of the page content */
-  display: none; /* Hidden by default */
-  width: 100%; /* Full width (cover the whole page) */
-  height: 100%; /* Full height (cover the whole page) */
+  position: fixed;
+  /* Sit on top of the page content */
+  display: none;
+  /* Hidden by default */
+  width: 100%;
+  /* Full width (cover the whole page) */
+  height: 100%;
+  /* Full height (cover the whole page) */
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
   opacity: 0;
-  background-color: rgba(0,30,50,0.6); /* Black background with opacity */
-  z-index: 2; /* Specify a stack order in case you're using a different order for other elements */
+  background-color: rgba(0, 30, 50, 0.6);
+  /* Black background with opacity */
+  z-index: 2;
+  /* Specify a stack order in case you're using a different order for other elements */
   transition: all 0.3s;
 }
 
@@ -413,9 +673,10 @@ select, [name="project_list"] {
 }
 
 /* Tutorial needs to be able to move around */
+
 #overlay_7 {
-  width: 45%; 
-  height: 60%; 
+  width: 45%;
+  height: 60%;
   padding: 2vh 2vw 2vh 2vw;
   position: absolute;
   top: 22.5vh;
@@ -434,12 +695,17 @@ select, [name="project_list"] {
 
 .top-icon {
   color: var(--top-icon-color);
-  float: left; margin-left: 10px; cursor: pointer;
-  display: flex!important; align-items: center; 
-  justify-content: center; font-size: 20px;
+  float: left;
+  margin-left: 10px;
+  cursor: pointer;
+  display: flex!important;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
 }
+
 .top-icon:first-child {
-  margin: 0; 
+  margin: 0;
 }
 
 .btn-view {
@@ -447,22 +713,27 @@ select, [name="project_list"] {
   color: var(--display-4-color);
   box-shadow: none;
   transition: all 0.5s;
-  font-size: calc(0.5vw + 0.5vh);
+  font-size: calc(0.8rem + 0.1vw + 0.1vh);
 }
+
 .btn-view:hover {
   filter: var(--hover-filter);
   color: var(--display-4-color);
 }
+
 .btn-view-active {
   border: var(--code-terminal-active);
   transition: all 0.5s;
 }
+
 #view_code {
   border-radius: 0 0 0 10px;
 }
+
 #view_output {
   border-radius: 0 0 0 0;
 }
+
 #outputview {
   border: 1px solid var(--editor-tab-close-color-hover);
   width: 50vw;
@@ -476,6 +747,7 @@ select, [name="project_list"] {
   color: var(--display-4-color);
   font: 16px/normal 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 }
+
 #view_terminal {
   border-radius: 0 0 10px 0;
 }
@@ -491,6 +763,7 @@ select, [name="project_list"] {
   border: 1px solid transparent;
   transition: border 0.3s;
 }
+
 .browser_row_file {
   width: 100%;
   height: 3vh;
@@ -501,15 +774,19 @@ select, [name="project_list"] {
   border: 1px solid transparent;
   transition: border 0.3s;
 }
+
 .browser_row_selected {
   border: 1px solid var(--display-4-color);
 }
+
 .browser_row:nth-child(odd) {
   background-color: var(--file-browser-row-odd);
 }
+
 .browser_row:nth-child(even) {
   background-color: var(--file-browser-row-eve);
 }
+
 #file_browser {
   width: 80%;
   height: 80%;
@@ -520,31 +797,33 @@ select, [name="project_list"] {
   background: transparent;
   overflow: auto;
 }
+
 .browser_row_file:hover {
   border: 1px solid var(--display-4-color);
 }
+
 .browser_row_col {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 
-               Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 
-               'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   color: var(--display-4-color);
   flex-grow: 1;
-  flex-basis: 1px; /* idk why but this keeps the column width a fixed size for any-sized text */
+  flex-basis: 1px;
+  /* idk why but this keeps the column width a fixed size for any-sized text */
   display: flex;
   align-items: center;
   justify-content: center;
   border-right: 1px solid var(--display-4-color);
   font-size: 14px;
 }
+
 .modern-font {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 
-               Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 
-               'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
+
 input[name="filedir"] {
-  display: none;  
+  display: none;
 }
-input[name="filedir"] + label {
+
+input[name="filedir"]+label {
   border: 1px solid transparent;
   transition: border 0.3s;
   padding: 0.25vh 0 0.25vh 0;
@@ -552,26 +831,29 @@ input[name="filedir"] + label {
 }
 
 .browser-view {
-  width: 100%; 
-  font-size: calc(0.5vw + 0.9vh); 
+  width: 100%;
+  font-size: calc(0.5vw + 0.9vh);
   color: var(--display-4-color);
 }
 
 label[for="newfile"] {
   border-radius: 10px 0 0 10px;
 }
+
 label[for="newfolder"] {
   border-radius: 0 10px 10px 0;
 }
-input[name="filedir"]:checked + label {
+
+input[name="filedir"]:checked+label {
   border: 1px solid var(--display-4-color);
 }
+
 #overlay_new_dirfile {
-  display: none; 
+  display: none;
   opacity: 0;
-  flex-direction: column; 
-  align-items: center; 
-  justify-content: space-between; 
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   height: 60%;
   position: absolute;
   top: 5%;
@@ -584,6 +866,7 @@ input[name="filedir"]:checked + label {
   z-index: 10;
   transition: opacity 0.3s;
 }
+
 #selworkspace {
   width: 55%;
   height: 3.4vh;
@@ -592,28 +875,30 @@ input[name="filedir"]:checked + label {
   border-radius: 2px;
   background-color: transparent;
 }
+
 .filedir_view {
-  width: 100%; 
-  height: 100%; 
-  flex-grow: 1; 
-  padding: 3vh 2vw 3vh 2vw; 
-  display: flex; 
-  flex-direction: column; 
-  align-items: center; 
+  width: 100%;
+  height: 100%;
+  flex-grow: 1;
+  padding: 3vh 2vw 3vh 2vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: space-evenly;
 }
+
 #add_new_folder_view {
   display: none;
 }
 
 #localport {
-  text-align: left; 
-  border-radius: 8px; 
+  text-align: left;
+  border-radius: 8px;
   margin-right: 1vw;
-  padding-left: 10px; 
-  padding-right: 10px; 
-  height: 3.5vh; 
-  width: 4.25vw; 
+  padding-left: 10px;
+  padding-right: 10px;
+  height: 3.5vh;
+  width: 4.25vw;
   font-size: 1.5vh;
   text-align: center;
 }
@@ -630,10 +915,10 @@ input[name="filedir"]:checked + label {
 }
 
 #share_id_input {
-  width: 50%; 
+  width: 50%;
   height: 4vh;
-  background: transparent; 
-  color: var(--display-4-color); 
+  background: transparent;
+  color: var(--display-4-color);
   border: 1px solid var(--display-4-color);
   border-radius: 5px;
   padding: 1%;
@@ -649,9 +934,9 @@ input[name="filedir"]:checked + label {
 }
 
 #div_workspace_gear {
-  position: absolute; 
-  width: 30%; 
-  height: 100%; 
+  position: absolute;
+  width: 30%;
+  height: 100%;
   padding: 3% 3% 0 0;
   top: 0%;
   left: 70%;
@@ -661,10 +946,10 @@ input[name="filedir"]:checked + label {
 }
 
 #workspace_gear {
-  font-size: calc(0.5vw); 
-  color: var(--display-4-color); 
+  font-size: calc(0.5vw);
+  color: var(--display-4-color);
   border: 1px solid transparent;
-  position: relative; 
+  position: relative;
   cursor: pointer;
   border-radius: 50%;
   padding: 10%;
@@ -722,6 +1007,7 @@ input[name="filedir"]:checked + label {
   border: 1px solid var(--display-4-color);
   border-radius: 5px;
 }
+
 .profile_text {
   width: 50%;
   font-weight: 300;
@@ -730,20 +1016,25 @@ input[name="filedir"]:checked + label {
   color: var(--display-4-color);
   transition: opacity 0.3s;
 }
+
 .profile_text:last-child {
   opacity: 0;
   border-left: 1px solid var(--display-4-color);
 }
+
 .profile_table tr:first-child th {
   padding-top: 1.5vh;
 }
+
 .profile_table tr:last-child th {
   padding-bottom: 1.5vh;
 }
 
 /* https://stackoverflow.com/questions/20435166/contenteditable-not-working-in-safari-but-works-in-chrome */
+
 /* This allows the user to edit the tab/workspace names on Safari, because as usual 
 Apple screws everything up for everyone who tries to develop on its platforms */
+
 [contenteditable] {
   -webkit-user-select: text;
   user-select: text;
@@ -759,41 +1050,46 @@ Apple screws everything up for everyone who tries to develop on its platforms */
   border: 1px solid var(--display-4-color);
   transition: all 0.3s;
 }
+
 .mbtn:hover:not(:disabled) {
   background: var(--tutorial-btn-bg-hover);
   color: var(--tutorial-btn-hover);
 }
 
 #resize-editor {
-  height: 33%; 
-  width: 1%; 
-  cursor: w-resize; 
-  background-color:transparent; 
+  height: 33%;
+  width: 1%;
+  cursor: w-resize;
+  background-color: transparent;
   border-left: 3px solid var(--display-4-color);
   transition: border 0.2s;
 }
+
 #resize-editor:hover {
-	border-left: 9px solid var(--display-4-color);
+  border-left: 9px solid var(--display-4-color);
 }
+
 /* sorry not sorry */
+
 #nevergonnagiveyouup:hover {
   filter: brightness(1.5);
 }
 
 /* frostyfinder! */
+
 .findallresult {
-    width: 90%;
-    padding: 3%;
-    padding: 1%;
-    border: 1px solid #bbb;
-    border-radius: 3px;
-    height: 15%;
+  width: 90%;
+  padding: 3%;
+  padding: 1%;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  height: 15%;
 }
 
 .findallresult p {
-	font-size: 14px;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-	margin: 0;
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  margin: 0;
 }
 
 .findallresult code {

--- a/assets/js/workspaces.js
+++ b/assets/js/workspaces.js
@@ -811,15 +811,19 @@ window.onload = function () {
 
 	$(document).mousemove (e => {
 		if ($('#resize-editor')[0].classList.contains ("dragging")) {
+			$("#editor-workspace").css("flex", "none")
 			if (e.pageX < last_page_x) {
 				// left
 				$("#editor-workspace").width($("#editor-workspace").width() - (last_page_x - e.pageX))
 				$("#outputview").width($("#editor-workspace").width() - (last_page_x - e.pageX))
 			}
 			else {
-				// right
-				$("#editor-workspace").width($("#editor-workspace").width() + (e.pageX - last_page_x))
-				$("#outputview").width($("#editor-workspace").width() + (e.pageX - last_page_x))
+				// right - make sure not to drag it larger than the width of the window!
+				if ($("#status-navbar").width() - $("#editor-workspace").width() - (e.pageX - last_page_x) >= 700
+						|| ($("#status-navbar").width() < 1675 &&  $("#editor-workspace").width() + (e.pageX - last_page_x) < 1600)) {
+					$("#editor-workspace").width($("#editor-workspace").width() + (e.pageX - last_page_x))
+					$("#outputview").width($("#editor-workspace").width() + (e.pageX - last_page_x))
+				}
 			}
 			last_page_x = e.pageX
 		}

--- a/assets/js/workspaces.js
+++ b/assets/js/workspaces.js
@@ -528,9 +528,12 @@ function openHDLwave() {
 }
 
 window.onload = function () {
-	var last_page_x = window.localStorage.editor_width || 2000;
-	$('#editor-workspace').width (window.localStorage.editor_width || '65%')
-	$('#outputview').width (window.localStorage.editor_width || '65%')
+	if (window.localStorage.editor_width) {
+		$("#editor-workspace").css("flex", "none")
+		$('#editor-workspace').width (window.localStorage.editor_width || '65%')
+		$('#outputview').width (window.localStorage.editor_width || '65%')
+	}
+    var last_page_x = $('#resize-editor').position().left;
 
 	window.addEventListener("mousewheel", codescroll, { passive: false })
 	// load_button.innerHTML = load_btn_text
@@ -811,7 +814,9 @@ window.onload = function () {
 
 	$(document).mousemove (e => {
 		if ($('#resize-editor')[0].classList.contains ("dragging")) {
-			$("#editor-workspace").css("flex", "none")
+			if (last_page_x == 0) { //first time adjusting the editor
+				last_page_x = $('#resize-editor').position().left;
+			}
 			if (e.pageX < last_page_x) {
 				// left
 				$("#editor-workspace").width($("#editor-workspace").width() - (last_page_x - e.pageX))
@@ -826,6 +831,7 @@ window.onload = function () {
 				}
 			}
 			last_page_x = e.pageX
+			$("#editor-workspace").css("flex", "none")
 		}
 	})
 

--- a/index.html
+++ b/index.html
@@ -99,256 +99,254 @@
       <p class="display-4 text-center text-muted" id="desctext"></p>
     </nav>
     <div style="padding-bottom: 1.5vh"> </div>
-    <div class="row justify-content-center">
-      <div class="row text-center d-sm-flex d-xl-flex justify-content-center" id="simview">
-        <div id="ice40-div">
-          <svg id="ice40HX8K" preserveAspectRatio="xMidYMid meet" viewBox="0 0 650 690" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <filter id="svg_127_blur" x="-50%" y="-50%" width="200%" height="200%">
-                <feGaussianBlur stdDeviation="0"/>
-              </filter>
-            </defs>
-            <g>
-              <rect x="-1" y="-1" width="610" height="702" id="canvas_background" fill="#17183f"/>
-              <g id="canvasGrid" display="none">
-                <rect id="svg_2" width="100%" height="100%" x="0" y="0" stroke-width="0" fill="url(#gridpattern)"/>
-              </g>
+    <div class="row text-center d-sm-flex d-xl-flex justify-content-center" id="simview">
+      <div id="ice40-div">
+        <svg id="ice40HX8K" preserveAspectRatio="xMidYMid meet" viewBox="0 0 610 690" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <filter id="svg_127_blur" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur stdDeviation="0"/>
+            </filter>
+          </defs>
+          <g>
+            <rect x="-1" y="-1" width="610" height="702" id="canvas_background" fill="#17183f"/>
+            <g id="canvasGrid" display="none">
+              <rect id="svg_2" width="100%" height="100%" x="0" y="0" stroke-width="0" fill="url(#gridpattern)"/>
             </g>
-            <rect fill="#111" stroke-width="1.5" x="29.136" y="32.413" width="64.193" height="123.425" id="svg_1" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss7_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="84.676" id="ss7_dp" style=""/>
-            <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="41.075" y1="95.817" x2="80.71" y2="95.817" id="ss7_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="20.11" y1="72.179" x2="59.189" y2="72.179" id="ss7_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 111.828501, 32.529501)"/>
-            <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="20.11" y1="113.053" x2="59.189" y2="113.053" id="ss7_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 152.702501, 73.403502)"/>
+          </g>
+          <rect fill="#111" stroke-width="1.5" x="29.136" y="32.413" width="64.193" height="123.425" id="svg_1" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss7_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="84.676" id="ss7_dp" style=""/>
+          <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="41.075" y1="95.817" x2="80.71" y2="95.817" id="ss7_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="20.11" y1="72.179" x2="59.189" y2="72.179" id="ss7_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 111.828501, 32.529501)"/>
+          <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="20.11" y1="113.053" x2="59.189" y2="113.053" id="ss7_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 152.702501, 73.403502)"/>
             <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="41.075" y1="133.21" x2="80.71" y2="133.21" id="ss7_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="62.422" y1="112.707" x2="101.731" y2="112.707" id="ss7_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 194.783503, 30.630499)"/>
-            <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="62.422" y1="71.833" x2="101.732" y2="71.833" id="ss7_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 153.910002, -10.244001)"/>
-            <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="41.075" y1="51.556" x2="80.71" y2="51.556" id="ss7_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <rect fill="#111" stroke-width="1.5" x="97.947" y="31.717" width="64.193" height="123.425" id="svg_23" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss6_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="153.423" id="ss7_dp" style=""/>
-            <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="110.251" y1="92.42" x2="149.884" y2="92.42" id="ss6_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="89.286" y1="72.262" x2="128.365" y2="72.262" id="ss6_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 181.087505, -36.563503)"/>
-            <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="89.285" y1="113.136" x2="128.364" y2="113.136" id="ss6_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 221.960503, 4.311501)"/>
-            <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="110.251" y1="133.294" x2="149.884" y2="133.294" id="ss6_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="131.598" y1="112.789" x2="170.906" y2="112.789" id="ss6_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 264.041008, -38.463005)"/>
-            <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="131.598" y1="71.916" x2="170.908" y2="71.916" id="ss6_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 223.169006, -79.337006)"/>
-            <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="110.251" y1="50.959" x2="149.884" y2="50.959" id="ss6_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <rect fill="#111" stroke-width="1.5" x="167.34" y="32.09" width="64.193" height="123.425" id="svg_79" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss5_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="222.892" id="ss7_dp" style=""/>
-            <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="179.645" y1="92.794" x2="219.28" y2="92.794" id="ss5_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="158.68" y1="72.636" x2="197.758" y2="72.636" id="ss5_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 250.854996, -105.582993)"/>
-            <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="158.679" y1="113.51" x2="197.758" y2="113.51" id="ss5_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 291.7285, -64.708496)"/>
-            <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="179.645" y1="133.668" x2="219.28" y2="133.668" id="ss5_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="200.992" y1="113.164" x2="240.3" y2="113.164" id="ss5_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 333.810005, -107.482002)"/>
-            <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="200.992" y1="72.29" x2="240.302" y2="72.29" id="ss5_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 292.937004, -148.357002)"/>
-            <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="179.645" y1="51.333" x2="219.28" y2="51.333" id="ss5_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <rect fill="#111" stroke-width="1.5" x="236.39" y="33.132" width="64.193" height="123.425" id="svg_87" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss4_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="292.486" id="ss7_dp" style=""/>
-            <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="248.695" y1="93.836" x2="288.328" y2="93.836" id="ss4_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="227.727" y1="73.678" x2="266.805" y2="73.678" id="ss4_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 320.944, -173.587997)"/>
-            <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="227.727" y1="114.552" x2="266.806" y2="114.552" id="ss4_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 361.818504, -132.7145)"/>
-            <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="248.695" y1="134.71" x2="288.328" y2="134.71" id="ss4_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="270.04" y1="114.206" x2="309.349" y2="114.206" id="ss4_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 403.900505, -175.488503)"/>
-            <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="270.042" y1="73.332" x2="309.352" y2="73.332" id="ss4_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 363.028992, -216.36499)"/>
-            <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="248.695" y1="52.376" x2="288.328" y2="52.376" id="ss4_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <rect fill="#111" stroke-width="1.5" x="305.373" y="32.793" width="64.193" height="123.425" id="svg_95" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss3_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="360.951" id="ss7_dp" style=""/>
-            <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="317.679" y1="93.496" x2="357.313" y2="93.496" id="ss3_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="296.712" y1="73.339" x2="335.791" y2="73.339" id="ss3_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 389.590492, -242.912498)"/>
-            <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="296.711" y1="114.212" x2="335.791" y2="114.212" id="ss3_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 430.46299, -202.038994)"/>
-            <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="317.679" y1="134.371" x2="357.313" y2="134.371" id="ss3_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="339.024" y1="113.866" x2="378.334" y2="113.866" id="ss3_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 472.544998, -244.813004)"/>
-            <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="339.025" y1="72.993" x2="378.335" y2="72.993" id="ss3_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 431.672989, -285.686996)"/>
-            <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="317.679" y1="52.036" x2="357.313" y2="52.036" id="ss3_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <rect fill="#111" stroke-width="1.5" x="374.526" y="33.835" width="64.193" height="123.425" id="svg_103" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss2_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="430.65" id="ss7_dp" style=""/>
-            <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="386.832" y1="94.539" x2="426.465" y2="94.539" id="ss2_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="365.865" y1="74.381" x2="404.944" y2="74.381" id="ss2_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 459.785492, -311.023499)"/>
-            <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="365.864" y1="115.255" x2="404.944" y2="115.255" id="ss2_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 500.659004, -270.14901)"/>
-            <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="386.832" y1="135.413" x2="426.465" y2="135.413" id="ss2_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="408.484" y1="115.106" x2="446.783" y2="115.106" id="ss2_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 542.739502, -312.527496)"/>
-            <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="408.178" y1="74.035" x2="447.488" y2="74.035" id="ss2_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 501.868011, -353.798004)"/>
-            <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="386.832" y1="53.078" x2="426.465" y2="53.078" id="ss2_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <rect fill="#111" stroke-width="1.5" x="443.92" y="33.251" width="64.193" height="123.425" id="svg_111" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss1_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="500.116" id="ss7_dp" style=""/>
-            <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="456.227" y1="93.953" x2="495.858" y2="93.953" id="ss1_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="435.258" y1="73.796" x2="474.338" y2="73.796" id="ss1_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 528.594002, -381.002007)"/>
-            <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="435.258" y1="114.669" x2="474.336" y2="114.669" id="ss1_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 569.465996, -340.127998)"/>
-            <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="456.227" y1="134.827" x2="495.858" y2="134.827" id="ss1_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="477.571" y1="114.324" x2="516.88" y2="114.324" id="ss1_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 611.549507, -382.901512)"/>
-            <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="477.571" y1="73.45" x2="516.881" y2="73.45" id="ss1_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 570.675995, -423.776001)"/>
-            <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="456.227" y1="52.493" x2="495.858" y2="52.493" id="ss1_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <rect fill="#111" stroke-width="1.5" x="514.077" y="33.333" width="64.193" height="123.425" id="svg_119" stroke="#000" opacity="0.5" style=""/>
-            <ellipse class="ss0_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="570.817" id="ss7_dp" style=""/>
-            <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="526.384" y1="94.036" x2="566.017" y2="94.036" id="ss0_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="505.416" y1="73.88" x2="544.495" y2="73.88" id="ss0_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 598.835487, -451.075493)"/>
-            <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="505.415" y1="114.754" x2="544.494" y2="114.754" id="ss0_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 639.708511, -410.200516)"/>
-            <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="526.384" y1="134.91" x2="566.017" y2="134.91" id="ss0_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="547.728" y1="114.408" x2="587.038" y2="114.408" id="ss0_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 681.791023, -452.975029)"/>
-            <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="547.728" y1="73.534" x2="587.036" y2="73.534" id="ss0_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 640.916016, -493.848022)"/>
-            <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="526.384" y1="52.577" x2="566.017" y2="52.577" id="ss0_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="254.644" cy="205.429" id="lf_0" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="224.291" cy="205.429" id="lf_1" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="194.697" cy="205.026" id="lf_2" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="164.778" cy="205.026" id="lf_3" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="134.74" cy="204.949" id="lf_4" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="104.386" cy="204.949" id="lf_5" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="74.792" cy="204.545" id="lf_6" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="44.873" cy="204.545" id="lf_7" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse id="rgbled" fill="#111" stroke-width="1.25" stroke-opacity="null" cx="303.1" cy="205.429" rx="15" ry="15" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="563.677" cy="205.429" id="rt_0" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="533.323" cy="205.429" id="rt_1" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="503.729" cy="205.026" id="rt_2" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="473.81" cy="205.026" id="rt_3" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="443.772" cy="204.949" id="rt_4" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="413.419" cy="204.949" id="rt_5" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="383.825" cy="204.545" id="rt_6" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="353.905" cy="204.545" id="rt_7" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyW'); return false;" onmouseup="javascript:toggle_button (event, 'keyW'); return false;" pressed="false" id="keyW" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyW'); return false;" onmouseup="javascript:toggle_button (event, 'keyW'); return false;" id="textW" x="438.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">W</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyX'); return false;" onmouseup="javascript:toggle_button (event, 'keyX'); return false;" pressed="false" id="keyX" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyX'); return false;" onmouseup="javascript:toggle_button (event, 'keyX'); return false;" id="textX" x="344.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">X</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyY'); return false;" onmouseup="javascript:toggle_button (event, 'keyY'); return false;" pressed="false" id="keyY" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyY'); return false;" onmouseup="javascript:toggle_button (event, 'keyY'); return false;" id="textY" x="250.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">Y</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyZ'); return false;" onmouseup="javascript:toggle_button (event, 'keyZ'); return false;" pressed="false" id="keyZ" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyZ'); return false;" onmouseup="javascript:toggle_button (event, 'keyZ'); return false;" id="textZ" x="155.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">Z</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyC'); return false;" onmouseup="javascript:toggle_button (event, 'keyC'); return false;" pressed="false" id="keyC" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyC'); return false;" onmouseup="javascript:toggle_button (event, 'keyC'); return false;" id="textC" x="438.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">C</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyD'); return false;" onmouseup="javascript:toggle_button (event, 'keyD'); return false;" pressed="false" id="keyD" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyD'); return false;" onmouseup="javascript:toggle_button (event, 'keyD'); return false;" id="textD" x="344.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">D</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyE'); return false;" onmouseup="javascript:toggle_button (event, 'keyE'); return false;" pressed="false" id="keyE" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyE'); return false;" onmouseup="javascript:toggle_button (event, 'keyE'); return false;" id="textE" x="250.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">E</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyF'); return false;" onmouseup="javascript:toggle_button (event, 'keyF'); return false;" pressed="false" id="keyF" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyF'); return false;" onmouseup="javascript:toggle_button (event, 'keyF'); return false;" id="textF" x="155.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">F</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key8'); return false;" onmouseup="javascript:toggle_button (event, 'key8'); return false;" pressed="false" id="key8" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key8'); return false;" onmouseup="javascript:toggle_button (event, 'key8'); return false;" id="text8" x="438.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">8</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key9'); return false;" onmouseup="javascript:toggle_button (event, 'key9'); return false;" pressed="false" id="key9" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key9'); return false;" onmouseup="javascript:toggle_button (event, 'key9'); return false;" id="text9" x="344.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">9</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyA'); return false;" onmouseup="javascript:toggle_button (event, 'keyA'); return false;" pressed="false" id="keyA" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyA'); return false;" onmouseup="javascript:toggle_button (event, 'keyA'); return false;" id="textA" x="250.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">A</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyB'); return false;" onmouseup="javascript:toggle_button (event, 'keyB'); return false;" pressed="false" id="keyB" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyB'); return false;" onmouseup="javascript:toggle_button (event, 'keyB'); return false;" id="textB" x="155.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">B</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key4'); return false;" onmouseup="javascript:toggle_button (event, 'key4'); return false;" pressed="false" id="key4" stroke="#000" fill="#333666" text="0" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key4'); return false;" onmouseup="javascript:toggle_button (event, 'key4'); return false;" id="text4" x="438.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">4</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key5'); return false;" onmouseup="javascript:toggle_button (event, 'key5'); return false;" pressed="false" id="key5" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key5'); return false;" onmouseup="javascript:toggle_button (event, 'key5'); return false;" id="text5" x="344.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">5</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key6'); return false;" onmouseup="javascript:toggle_button (event, 'key6'); return false;" pressed="false" id="key6" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key6'); return false;" onmouseup="javascript:toggle_button (event, 'key6'); return false;" id="text6" x="250.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">6</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key7'); return false;" onmouseup="javascript:toggle_button (event, 'key7'); return false;" pressed="false" id="key7" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key7'); return false;" onmouseup="javascript:toggle_button (event, 'key7'); return false;" id="text7" x="155.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">7</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key0'); return false;" onmouseup="javascript:toggle_button (event, 'key0'); return false;" pressed="false" id="key0" stroke="#000" fill="#333666" text="0" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key0'); return false;" onmouseup="javascript:toggle_button (event, 'key0'); return false;" id="text0" x="438.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">0</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key1'); return false;" onmouseup="javascript:toggle_button (event, 'key1'); return false;" pressed="false" id="key1" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key1'); return false;" onmouseup="javascript:toggle_button (event, 'key1'); return false;" id="text1" x="344.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">1</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key2'); return false;" onmouseup="javascript:toggle_button (event, 'key2'); return false;" pressed="false" id="key2" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key2'); return false;" onmouseup="javascript:toggle_button (event, 'key2'); return false;" id="text2" x="250.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">2</text>
-            </g>
-            <g>
-                <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key3'); return false;" onmouseup="javascript:toggle_button (event, 'key3'); return false;" pressed="false" id="key3" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
-                <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key3'); return false;" onmouseup="javascript:toggle_button (event, 'key3'); return false;" id="text3" x="155.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">3</text>
-            </g>
-          </svg>
-          <div class="col align-self-center">
-            <div class="d-xl-flex justify-content-xl-center">
-              <div class="row btn-row">
-                <button class="btn btn-info btn-bevel btn-filter" id="btn-load"  type="button"  onclick="javascript:load_template(event)">Load Template</button>
-                <button class="btn btn-primary btn-bevel btn-filter"             type="button"  onclick="javascript:ice40hx8k_handler();">Simulate</button>
-              </div>
+          <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="62.422" y1="112.707" x2="101.731" y2="112.707" id="ss7_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 194.783503, 30.630499)"/>
+          <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="62.422" y1="71.833" x2="101.732" y2="71.833" id="ss7_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 153.910002, -10.244001)"/>
+          <line class="ss7_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="41.075" y1="51.556" x2="80.71" y2="51.556" id="ss7_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <rect fill="#111" stroke-width="1.5" x="97.947" y="31.717" width="64.193" height="123.425" id="svg_23" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss6_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="153.423" id="ss7_dp" style=""/>
+          <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="110.251" y1="92.42" x2="149.884" y2="92.42" id="ss6_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="89.286" y1="72.262" x2="128.365" y2="72.262" id="ss6_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 181.087505, -36.563503)"/>
+          <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="89.285" y1="113.136" x2="128.364" y2="113.136" id="ss6_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 221.960503, 4.311501)"/>
+          <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="110.251" y1="133.294" x2="149.884" y2="133.294" id="ss6_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="131.598" y1="112.789" x2="170.906" y2="112.789" id="ss6_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 264.041008, -38.463005)"/>
+          <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="131.598" y1="71.916" x2="170.908" y2="71.916" id="ss6_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 223.169006, -79.337006)"/>
+          <line class="ss6_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="110.251" y1="50.959" x2="149.884" y2="50.959" id="ss6_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <rect fill="#111" stroke-width="1.5" x="167.34" y="32.09" width="64.193" height="123.425" id="svg_79" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss5_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="222.892" id="ss7_dp" style=""/>
+          <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="179.645" y1="92.794" x2="219.28" y2="92.794" id="ss5_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="158.68" y1="72.636" x2="197.758" y2="72.636" id="ss5_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 250.854996, -105.582993)"/>
+          <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="158.679" y1="113.51" x2="197.758" y2="113.51" id="ss5_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 291.7285, -64.708496)"/>
+          <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="179.645" y1="133.668" x2="219.28" y2="133.668" id="ss5_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="200.992" y1="113.164" x2="240.3" y2="113.164" id="ss5_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 333.810005, -107.482002)"/>
+          <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="200.992" y1="72.29" x2="240.302" y2="72.29" id="ss5_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 292.937004, -148.357002)"/>
+          <line class="ss5_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="179.645" y1="51.333" x2="219.28" y2="51.333" id="ss5_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <rect fill="#111" stroke-width="1.5" x="236.39" y="33.132" width="64.193" height="123.425" id="svg_87" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss4_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="292.486" id="ss7_dp" style=""/>
+          <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="248.695" y1="93.836" x2="288.328" y2="93.836" id="ss4_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="227.727" y1="73.678" x2="266.805" y2="73.678" id="ss4_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 320.944, -173.587997)"/>
+          <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="227.727" y1="114.552" x2="266.806" y2="114.552" id="ss4_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 361.818504, -132.7145)"/>
+          <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="248.695" y1="134.71" x2="288.328" y2="134.71" id="ss4_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="270.04" y1="114.206" x2="309.349" y2="114.206" id="ss4_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 403.900505, -175.488503)"/>
+          <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="270.042" y1="73.332" x2="309.352" y2="73.332" id="ss4_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 363.028992, -216.36499)"/>
+          <line class="ss4_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="248.695" y1="52.376" x2="288.328" y2="52.376" id="ss4_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <rect fill="#111" stroke-width="1.5" x="305.373" y="32.793" width="64.193" height="123.425" id="svg_95" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss3_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="360.951" id="ss7_dp" style=""/>
+          <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="317.679" y1="93.496" x2="357.313" y2="93.496" id="ss3_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="296.712" y1="73.339" x2="335.791" y2="73.339" id="ss3_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 389.590492, -242.912498)"/>
+          <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="296.711" y1="114.212" x2="335.791" y2="114.212" id="ss3_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 430.46299, -202.038994)"/>
+          <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="317.679" y1="134.371" x2="357.313" y2="134.371" id="ss3_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="339.024" y1="113.866" x2="378.334" y2="113.866" id="ss3_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 472.544998, -244.813004)"/>
+          <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="339.025" y1="72.993" x2="378.335" y2="72.993" id="ss3_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 431.672989, -285.686996)"/>
+          <line class="ss3_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="317.679" y1="52.036" x2="357.313" y2="52.036" id="ss3_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <rect fill="#111" stroke-width="1.5" x="374.526" y="33.835" width="64.193" height="123.425" id="svg_103" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss2_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="430.65" id="ss7_dp" style=""/>
+          <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="386.832" y1="94.539" x2="426.465" y2="94.539" id="ss2_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="365.865" y1="74.381" x2="404.944" y2="74.381" id="ss2_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 459.785492, -311.023499)"/>
+          <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="365.864" y1="115.255" x2="404.944" y2="115.255" id="ss2_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 500.659004, -270.14901)"/>
+          <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="386.832" y1="135.413" x2="426.465" y2="135.413" id="ss2_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="408.484" y1="115.106" x2="446.783" y2="115.106" id="ss2_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 542.739502, -312.527496)"/>
+          <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="408.178" y1="74.035" x2="447.488" y2="74.035" id="ss2_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 501.868011, -353.798004)"/>
+          <line class="ss2_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="386.832" y1="53.078" x2="426.465" y2="53.078" id="ss2_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <rect fill="#111" stroke-width="1.5" x="443.92" y="33.251" width="64.193" height="123.425" id="svg_111" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss1_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="500.116" id="ss7_dp" style=""/>
+          <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="456.227" y1="93.953" x2="495.858" y2="93.953" id="ss1_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="435.258" y1="73.796" x2="474.338" y2="73.796" id="ss1_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 528.594002, -381.002007)"/>
+          <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="435.258" y1="114.669" x2="474.336" y2="114.669" id="ss1_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 569.465996, -340.127998)"/>
+          <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="456.227" y1="134.827" x2="495.858" y2="134.827" id="ss1_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="477.571" y1="114.324" x2="516.88" y2="114.324" id="ss1_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 611.549507, -382.901512)"/>
+          <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="477.571" y1="73.45" x2="516.881" y2="73.45" id="ss1_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 570.675995, -423.776001)"/>
+          <line class="ss1_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="456.227" y1="52.493" x2="495.858" y2="52.493" id="ss1_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <rect fill="#111" stroke-width="1.5" x="514.077" y="33.333" width="64.193" height="123.425" id="svg_119" stroke="#000" opacity="0.5" style=""/>
+          <ellipse class="ss0_line" fill="#222" stroke="#333" stroke-width="3" stroke-opacity="null" fill-opacity="null" filter="url(#svg_127_blur)" ry="2.321" rx="2.425" cy="143.624" cx="570.817" id="ss7_dp" style=""/>
+          <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="526.384" y1="94.036" x2="566.017" y2="94.036" id="ss0_g" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="505.416" y1="73.88" x2="544.495" y2="73.88" id="ss0_f" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 598.835487, -451.075493)"/>
+          <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="505.415" y1="114.754" x2="544.494" y2="114.754" id="ss0_e" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 639.708511, -410.200516)"/>
+          <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="526.384" y1="134.91" x2="566.017" y2="134.91" id="ss0_d" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="547.728" y1="114.408" x2="587.038" y2="114.408" id="ss0_c" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 681.791023, -452.975029)"/>
+          <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="547.728" y1="73.534" x2="587.036" y2="73.534" id="ss0_b" stroke-linejoin="bevel" stroke-linecap="round" style="" transform="matrix(0, 1, -1, 0, 640.916016, -493.848022)"/>
+          <line class="ss0_line" fill="#222" stroke="#333" stroke-width="4" stroke-opacity="null" fill-opacity="null" x1="526.384" y1="52.577" x2="566.017" y2="52.577" id="ss0_a" stroke-linejoin="bevel" stroke-linecap="round" style=""/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="254.644" cy="205.429" id="lf_0" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="224.291" cy="205.429" id="lf_1" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="194.697" cy="205.026" id="lf_2" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="164.778" cy="205.026" id="lf_3" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="134.74" cy="204.949" id="lf_4" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="104.386" cy="204.949" id="lf_5" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="74.792" cy="204.545" id="lf_6" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="lftred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="44.873" cy="204.545" id="lf_7" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse id="rgbled" fill="#111" stroke-width="1.25" stroke-opacity="null" cx="303.1" cy="205.429" rx="15" ry="15" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="563.677" cy="205.429" id="rt_0" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="533.323" cy="205.429" id="rt_1" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="503.729" cy="205.026" id="rt_2" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="473.81" cy="205.026" id="rt_3" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="443.772" cy="204.949" id="rt_4" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="413.419" cy="204.949" id="rt_5" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="383.825" cy="204.545" id="rt_6" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <ellipse class="rgtred" fill="#300" stroke-width="1.25" stroke-opacity="null" cx="353.905" cy="204.545" id="rt_7" rx="11.157" ry="11.157" filter="url(#svg_127_blur)" stroke="#000"/>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyW'); return false;" onmouseup="javascript:toggle_button (event, 'keyW'); return false;" pressed="false" id="keyW" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyW'); return false;" onmouseup="javascript:toggle_button (event, 'keyW'); return false;" id="textW" x="438.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">W</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyX'); return false;" onmouseup="javascript:toggle_button (event, 'keyX'); return false;" pressed="false" id="keyX" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyX'); return false;" onmouseup="javascript:toggle_button (event, 'keyX'); return false;" id="textX" x="344.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">X</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyY'); return false;" onmouseup="javascript:toggle_button (event, 'keyY'); return false;" pressed="false" id="keyY" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyY'); return false;" onmouseup="javascript:toggle_button (event, 'keyY'); return false;" id="textY" x="250.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">Y</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyZ'); return false;" onmouseup="javascript:toggle_button (event, 'keyZ'); return false;" pressed="false" id="keyZ" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="258.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyZ'); return false;" onmouseup="javascript:toggle_button (event, 'keyZ'); return false;" id="textZ" x="155.129016" y="298.5" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">Z</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyC'); return false;" onmouseup="javascript:toggle_button (event, 'keyC'); return false;" pressed="false" id="keyC" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyC'); return false;" onmouseup="javascript:toggle_button (event, 'keyC'); return false;" id="textC" x="438.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">C</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyD'); return false;" onmouseup="javascript:toggle_button (event, 'keyD'); return false;" pressed="false" id="keyD" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyD'); return false;" onmouseup="javascript:toggle_button (event, 'keyD'); return false;" id="textD" x="344.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">D</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyE'); return false;" onmouseup="javascript:toggle_button (event, 'keyE'); return false;" pressed="false" id="keyE" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyE'); return false;" onmouseup="javascript:toggle_button (event, 'keyE'); return false;" id="textE" x="250.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">E</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyF'); return false;" onmouseup="javascript:toggle_button (event, 'keyF'); return false;" pressed="false" id="keyF" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="336.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyF'); return false;" onmouseup="javascript:toggle_button (event, 'keyF'); return false;" id="textF" x="155.129016" y="376.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">F</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key8'); return false;" onmouseup="javascript:toggle_button (event, 'key8'); return false;" pressed="false" id="key8" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key8'); return false;" onmouseup="javascript:toggle_button (event, 'key8'); return false;" id="text8" x="438.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">8</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key9'); return false;" onmouseup="javascript:toggle_button (event, 'key9'); return false;" pressed="false" id="key9" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key9'); return false;" onmouseup="javascript:toggle_button (event, 'key9'); return false;" id="text9" x="344.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">9</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyA'); return false;" onmouseup="javascript:toggle_button (event, 'keyA'); return false;" pressed="false" id="keyA" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyA'); return false;" onmouseup="javascript:toggle_button (event, 'keyA'); return false;" id="textA" x="250.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">A</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'keyB'); return false;" onmouseup="javascript:toggle_button (event, 'keyB'); return false;" pressed="false" id="keyB" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="415.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'keyB'); return false;" onmouseup="javascript:toggle_button (event, 'keyB'); return false;" id="textB" x="155.129016" y="455.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">B</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key4'); return false;" onmouseup="javascript:toggle_button (event, 'key4'); return false;" pressed="false" id="key4" stroke="#000" fill="#333666" text="0" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key4'); return false;" onmouseup="javascript:toggle_button (event, 'key4'); return false;" id="text4" x="438.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">4</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key5'); return false;" onmouseup="javascript:toggle_button (event, 'key5'); return false;" pressed="false" id="key5" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key5'); return false;" onmouseup="javascript:toggle_button (event, 'key5'); return false;" id="text5" x="344.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">5</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key6'); return false;" onmouseup="javascript:toggle_button (event, 'key6'); return false;" pressed="false" id="key6" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key6'); return false;" onmouseup="javascript:toggle_button (event, 'key6'); return false;" id="text6" x="250.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">6</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key7'); return false;" onmouseup="javascript:toggle_button (event, 'key7'); return false;" pressed="false" id="key7" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="495.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key7'); return false;" onmouseup="javascript:toggle_button (event, 'key7'); return false;" id="text7" x="155.129016" y="535.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">7</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key0'); return false;" onmouseup="javascript:toggle_button (event, 'key0'); return false;" pressed="false" id="key0" stroke="#000" fill="#333666" text="0" stroke-width="1.25" stroke-opacity="null" x="413.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key0'); return false;" onmouseup="javascript:toggle_button (event, 'key0'); return false;" id="text0" x="438.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">0</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key1'); return false;" onmouseup="javascript:toggle_button (event, 'key1'); return false;" pressed="false" id="key1" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="318.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key1'); return false;" onmouseup="javascript:toggle_button (event, 'key1'); return false;" id="text1" x="344.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">1</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key2'); return false;" onmouseup="javascript:toggle_button (event, 'key2'); return false;" pressed="false" id="key2" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="224.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key2'); return false;" onmouseup="javascript:toggle_button (event, 'key2'); return false;" id="text2" x="250.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">2</text>
+          </g>
+          <g>
+              <rect class="inputbutton" onmousedown="javascript:toggle_button (event, 'key3'); return false;" onmouseup="javascript:toggle_button (event, 'key3'); return false;" pressed="false" id="key3" stroke="#000" fill="#333666" stroke-width="1.25" stroke-opacity="null" x="130.129016" y="575.129053" width="64.838718" height="65.483867" style="cursor: pointer" rx="5"/>
+              <text class="svg_text" onmousedown="javascript:toggle_button (event, 'key3'); return false;" onmouseup="javascript:toggle_button (event, 'key3'); return false;" id="text3" x="155.129016" y="615.129053" font-family="Courier" font-size="28" fill="white" style="cursor: pointer; white-space: pre;">3</text>
+          </g>
+        </svg>
+        <div class="col align-self-center">
+          <div class="d-xl-flex justify-content-xl-center">
+            <div class="row btn-row">
+              <button class="btn btn-info btn-bevel btn-filter" id="btn-load"  type="button"  onclick="javascript:load_template(event)">Load Template</button>
+              <button class="btn btn-primary btn-bevel btn-filter"             type="button"  onclick="javascript:ice40hx8k_handler();">Simulate</button>
             </div>
-            <div class="d-xl-flex justify-content-xl-center">
-              <div class="row btn-row">
-                <button class="btn btn-dark btn-bevel btn-filter"    type="button" onclick="javascript:demo_handler()">Demo</button>
-                <button class="btn btn-warning btn-bevel btn-filter" type="button" onclick="javascript:stop_handler()">Freeze</button>
-                <button class="btn btn-danger btn-bevel btn-filter" type="button" onclick="javascript:reset_handler()">Stop</button>
-              </div>
+          </div>
+          <div class="d-xl-flex justify-content-xl-center">
+            <div class="row btn-row">
+              <button class="btn btn-dark btn-bevel btn-filter"    type="button" onclick="javascript:demo_handler()">Demo</button>
+              <button class="btn btn-warning btn-bevel btn-filter" type="button" onclick="javascript:stop_handler()">Freeze</button>
+              <button class="btn btn-danger btn-bevel btn-filter" type="button" onclick="javascript:reset_handler()">Stop</button>
             </div>
-            <div class="d-xl-flex justify-content-xl-center">
-              <div class="btn-row row justify-content-xl-center">
-                <button class="btn btn-bevel btn-filter lowerbtn" id="switchsim" type="button" onclick="javascript:switchWorkspaceSim()">Workspace Simulation</button>
-                <button class="btn btn-bevel btn-filter lowerbtn" type="button" onclick="javascript:openHDLwave();">Verify Design</button>
-              </div>
+          </div>
+          <div class="d-xl-flex justify-content-xl-center">
+            <div class="btn-row row justify-content-xl-center">
+              <button class="btn btn-bevel btn-filter lowerbtn" id="switchsim" type="button" onclick="javascript:switchWorkspaceSim()">Workspace Simulation</button>
+              <button class="btn btn-bevel btn-filter lowerbtn" type="button" onclick="javascript:openHDLwave();">Verify Design</button>
             </div>
           </div>
         </div>
-        <div id="editor-workspace">
-          <div style="width: 100%; height: 100%; display: flex; flex-direction: column;">
-            <div id="editor-tab-workspace-header">
-                <div class="editor-tab-workspace" id="editor-tab-workspace-add"><label class="tab-label-workspace" id="wksp-tab-add">+</label></div>
-            </div>
-            <div id="editor-tab-header">
-              <div class="editor-tab" id="editor-tab-add"><label class="tab-label" id="tab-add">+</label></div>
-            </div>
-            <div class="wrapped-editor">
-              <div id="codemirror_box" style="width: 100%; top: 0; bottom: 0; left: 0; right: 0; z-index: 0"></div>
-              <div class="radar-view" id="radar-view" style="position: relative;"></div>
-            </div>
-            <div id="terminal" style="display: none"></div>
-            <textarea id="outputview" readonly style="display: none">No output has been produced from a simulation yet.</textarea>
-            <script src="assets/js/ace-builds/src-noconflict/ext-language_tools.js"></script>
-            <script>
-              ace.require("ace/ext/language_tools");
-              var editor = ace.edit ("codemirror_box")
-              if (!localStorage.codeAutocomplete || localStorage.codeAutocomplete == "true") {
-                editor.setOptions({
-                  enableBasicAutocompletion: true,
-                  enableSnippets: true,
-                  enableLiveAutocompletion: true
-                });
-                if (!localStorage.codeAutocomplete)
-                  localStorage.codeAutocomplete = "true"
-              }
-              var EditSession = ace.require ("ace/edit_session").EditSession
-              editor.setTheme ("ace/theme/chrome")
-              editor.session.setMode("ace/mode/verilog")
-              editor.session.setTabSize(2)
-              document.getElementById('codemirror_box').style.fontSize='14px';
-              editor.setShowPrintMargin(false);
-              var Range = ace.require('ace/range').Range;
-            </script>
-            <div id="uart_view" style="width: 100%; display: flex; flex-direction: row; align-items: center; justify-content: flex-start;">
-              <button class="btn btn-bevel btn-view btn-view-active" id="view_code" onclick="switchView(0)">Code View</button>
-              <button class="btn btn-bevel btn-view" id="view_output" onclick="switchView(2)">Tool Output</button>
-              <button class="btn btn-bevel btn-view" id="view_terminal" onclick="switchView(1)">Terminal View</button>
-            </div>
+      </div>
+      <div id="editor-workspace">
+        <div style="width: 100%; height: 100%; display: flex; flex-direction: column;">
+          <div id="editor-tab-workspace-header">
+              <div class="editor-tab-workspace" id="editor-tab-workspace-add"><label class="tab-label-workspace" id="wksp-tab-add">+</label></div>
           </div>
-          <div id="resize-editor" draggable="true"></div>
+          <div id="editor-tab-header">
+            <div class="editor-tab" id="editor-tab-add"><label class="tab-label" id="tab-add">+</label></div>
+          </div>
+          <div class="wrapped-editor">
+            <div id="codemirror_box" style="width: 100%; top: 0; bottom: 0; left: 0; right: 0; z-index: 0"></div>
+            <div class="radar-view" id="radar-view" style="position: relative;"></div>
+          </div>
+          <div id="terminal" style="display: none"></div>
+          <textarea id="outputview" readonly style="display: none">No output has been produced from a simulation yet.</textarea>
+          <script src="assets/js/ace-builds/src-noconflict/ext-language_tools.js"></script>
+          <script>
+            ace.require("ace/ext/language_tools");
+            var editor = ace.edit ("codemirror_box")
+            if (!localStorage.codeAutocomplete || localStorage.codeAutocomplete == "true") {
+              editor.setOptions({
+                enableBasicAutocompletion: true,
+                enableSnippets: true,
+                enableLiveAutocompletion: true
+              });
+              if (!localStorage.codeAutocomplete)
+                localStorage.codeAutocomplete = "true"
+            }
+            var EditSession = ace.require ("ace/edit_session").EditSession
+            editor.setTheme ("ace/theme/chrome")
+            editor.session.setMode("ace/mode/verilog")
+            editor.session.setTabSize(2)
+            document.getElementById('codemirror_box').style.fontSize='14px';
+            editor.setShowPrintMargin(false);
+            var Range = ace.require('ace/range').Range;
+          </script>
+          <div id="uart_view" style="width: 100%; display: flex; flex-direction: row; align-items: center; justify-content: flex-start;">
+            <button class="btn btn-bevel btn-view btn-view-active" id="view_code" onclick="switchView(0)">Code View</button>
+            <button class="btn btn-bevel btn-view" id="view_output" onclick="switchView(2)">Tool Output</button>
+            <button class="btn btn-bevel btn-view" id="view_terminal" onclick="switchView(1)">Terminal View</button>
+          </div>
         </div>
+        <div id="resize-editor" draggable="true"></div>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -347,7 +347,7 @@
               <button class="btn btn-bevel btn-view" id="view_terminal" onclick="switchView(1)">Terminal View</button>
             </div>
           </div>
-          <div id="resize-editor" style="height: 20%; width: 1%; cursor: w-resize; background-color:transparent; border-left: 3px solid var(--display-4-color)" draggable="true"></div>
+          <div id="resize-editor" draggable="true"></div>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -39,23 +39,23 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 </head>
 
-<body onresize="resizeHandler()" style="height: 100vh; background-color: var(--navbar-upper-bg);">
-  <div class="findall" style="width: 400px; height: 500px; position: absolute; top: 25vh; left: 25vw; z-index: 100; display: none; opacity: 0; transition: opacity 0.3s ease 0s; background: rgba(255, 255, 255, 0.7) none repeat scroll 0% 0%; border: 2px solid var(--display-4-color); border-radius: 5px;">
-    <div class="findalltop" style="width:100%; height: 2.5%; background: #fff"></div>
-    <div class="findallbkgd" style="width:100%;height:95%;filter: blur(10px); z-index: 99; background: rgba(255, 255, 255, 0.65);"></div>
-    <div class="findallbody" style="width:100%;height:95%;filter: blur(0px); position: absolute; top: 2.5%; left: 0; z-index: 101; background: transparent; display: flex; align-items: center; padding-top: 20px; justify-content: flex-start; flex-direction: column; overflow-x: hidden; overflow-y: scroll">
-      <div style="display: flex; flex-direction: row; align-items: center; justify-content: center; width: 95%;height: 10%;">
-        <i class="fa fa-search" aria-hidden="true" style="margin-right: 15px;font-size: calc(1vw + 1vh);"></i>
-        <input id="findallsearch" style="width: 85%;font-family: Open Sans;background: transparent;border: 1px solid #888;border-radius: 5px;padding-left: 10px;height: 100%;font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;" placeholder="Enter a search string...">
+<body onresize="resizeHandler()">
+  <div class="findall">
+    <div class="findalltop"></div>
+    <div class="findallbkgd"></div>
+    <div class="findallbody">
+      <div class="findallwindow">
+        <i class="fa fa-search" aria-hidden="true"></i>
+        <input id="findallsearch" placeholder="Enter a search string...">
       </div>
-      <p id="findallstatus" style="font-size: 14px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;width: 90%;margin-top: 15px;margin-bottom: 5px;">Enter at least three characters.</p>
+      <p id="findallstatus">Enter at least three characters.</p>
     </div>
   </div>
-  <div class="overlay" id="overlay_top" style="background-color: var(--navbar-upper-bg); display: block; opacity: 1"></div>
-  <div id="mainview" style="width: 100%;height:100%;margin-right: auto;margin-left: auto;transition: filter 0.75s">
-    <nav class="navbar navbar-light navbar-special navbar-expand-md navigation-clean-button theme-select" style="height: 8vh;">
-      <div class="d-flex align-items-center" style="width: 100%; flex-direction: row; justify-content: space-evenly;">
-        <div style="display: flex; flex-direction: row; align-items: center; justify-content: center;">
+  <div class="overlay" id="overlay_top"></div>
+  <div id="mainview">
+    <nav class="navbar navbar-light navbar-special navbar-expand-md navigation-clean-button theme-select" id="header-title">
+      <div class="d-flex align-items-center" id="header-flex">
+        <div id="header-row">
           <!-- <input id="save_as_elm" type="file" name="name" style="display: none"/> -->
           <!-- <button class="btn btn-light btn-bevel" type="button" style="float: right; width: 100px; font-size: 16px; margin-right: 15px" onclick="javascript:document.getElementById('open_elm').click()">Open</button> -->
           <i class="fal fa-file top-icon" title="Create new workspace/file" onclick="javascript:openWorkspaceManager('create')"></i>
@@ -71,37 +71,37 @@
           <input id="open_elm" type="file" name="name" style="display: none"/>
           <a id="downlink" href="none" download="verilog.sv" style="display: none"></a>
         </div>
-        <h1 title="There's Easter eggs all over the site!  Seek and ye shall find, and ye shall tell us on Piazza!" class="display-4 text-center text-muted" style="font-size: calc(1.3vw + 0.5vh); width: auto; margin: 0 10vw 0 10vw">eceFPGA Simulator</h1>
-        <div style="width: 10%; height: auto; display: flex; flex-direction: row; align-items: center">
-          <p class="display-4 text-muted" style="cursor: pointer; font-size: calc(0.8vw + 0.25vh); margin: 0" onclick="zipStorage()">Download as zip</p>
+        <h1 title="There's Easter eggs all over the site!  Seek and ye shall find, and ye shall tell us on Piazza!" class="display-4 text-center text-muted title">eceFPGA Simulator</h1>
+        <div class="download-div">
+          <p class="display-4 text-muted download-button" onclick="zipStorage()">Download as zip</p>
         </div>
       </div>
     </nav>
-    <nav class="navbar navbar-page-info navbar-special" id="status-navbar" style="vertical-align: middle; padding: 0px!important; background-color: #eaeaea">
-      <div class="d-flex justify-content-center" style="width: 100%; height: 100%; padding-top: 1.25vh; padding-bottom: 0.75vh">
-        <div class="col" style="height: 100%">
-          <div class="row justify-content-center" style="vertical-align: middle; margin-left: 5vw; padding-right: 3vw;">
+    <nav class="navbar navbar-page-info navbar-special" id="status-navbar">
+      <div class="d-flex justify-content-center">
+        <div class="col">
+          <div class="row justify-content-center">
             <div class="col">
-              <h1 class="display-4 text-center text-muted" id="status-text" style="font-size: calc(0.4vh + 0.8vw);">Status: Ready</h1>
+              <h1 class="display-4 text-center text-muted" id="status-text">Status: Ready</h1>
             </div>
-            <a onclick="javascript:display_info(0); return false;"><h1 class="desc display-4 text-center text-muted" id="status-text" style="cursor: pointer; border-right: 1px solid gray; padding-left: 2.25vw; padding-right: 2.25vw; font-size: calc(0.4vh + 0.8vw);">About</h1></a>
-            <a onclick="javascript:display_info(1); return false;"><h1 class="desc display-4 text-center text-muted" id="status-text" style="cursor: pointer; border-right: 1px solid gray; padding-left: 2.25vw; padding-right: 2.25vw; font-size: calc(0.4vh + 0.8vw);">Functionality</h1></a>
-            <a onclick="javascript:display_info(2); return false;"><h1 class="desc display-4 text-center text-muted" id="status-text" style="cursor: pointer; border-right: 1px solid gray; padding-left: 2.25vw; padding-right: 2.25vw; font-size: calc(0.4vh + 0.8vw);">Usage</h1></a>
-            <a onclick="javascript:display_info(3); return false;"><h1 class="desc display-4 text-center text-muted" id="status-text" style="cursor: pointer; border-right: 1px solid gray; padding-left: 2.25vw; padding-right: 2.25vw; font-size: calc(0.4vh + 0.8vw);">Credits</h1></a>
-            <a onclick="javascript:display_info(4); return false;"><h1 class="desc display-4 text-center text-muted" id="status-text" style="cursor: pointer; border-right: 1px solid gray; padding-left: 2.25vw; padding-right: 2.25vw; font-size: calc(0.4vh + 0.8vw);">Privacy</h1></a>
-            <a onclick="javascript:display_info(5); return false;"><h1 class="desc display-4 text-center text-muted" id="status-text" style="cursor: pointer;                                 padding-left: 2.25vw; padding-right: 2.25vw; font-size: calc(0.4vh + 0.8vw);">Source</h1></a>
+            <a onclick="javascript:display_info(0); return false;"><h1 class="desc display-4 text-center text-muted">About</h1></a>
+            <a onclick="javascript:display_info(1); return false;"><h1 class="desc display-4 text-center text-muted">Functionality</h1></a>
+            <a onclick="javascript:display_info(2); return false;"><h1 class="desc display-4 text-center text-muted">Usage</h1></a>
+            <a onclick="javascript:display_info(3); return false;"><h1 class="desc display-4 text-center text-muted">Credits</h1></a>
+            <a onclick="javascript:display_info(4); return false;"><h1 class="desc display-4 text-center text-muted">Privacy</h1></a>
+            <a onclick="javascript:display_info(5); return false;"><h1 class="desc display-4 text-center text-muted"style="border-right: 0;">Source</h1></a>
             <div style="margin-left: 10vw"></div>
           </div>
         </div>
       </div>
     </nav>
     <nav class="description-navbar" id="description-navbar" style="overflow: hidden; position: fixed; z-index: 2; background-color: #dfdfdf; height: 0vh; transition: height 0.3s">
-      <p class="display-4 text-center text-muted" id="desctext" style="padding-top: 2vh; padding-left: 20vw; padding-right: 20vw; font-size: calc(0.3vh + 0.78vw)"></p>
+      <p class="display-4 text-center text-muted" id="desctext"></p>
     </nav>
     <div style="padding-bottom: 1.5vh"> </div>
     <div class="row justify-content-center">
-      <div class="row text-center d-sm-flex d-xl-flex justify-content-center" style="text-align: center; align-items: center; width: 100%">
-        <div class="col-md-6" style="width: 25%; max-width: calc(15vw + 20vh); padding-right: 1px">
+      <div class="row text-center d-sm-flex d-xl-flex justify-content-center" id="simview">
+        <div id="ice40-div">
           <svg id="ice40HX8K" preserveAspectRatio="xMidYMid meet" viewBox="0 0 650 690" xmlns="http://www.w3.org/2000/svg">
             <defs>
               <filter id="svg_127_blur" x="-50%" y="-50%" width="200%" height="200%">
@@ -286,42 +286,27 @@
           </svg>
           <div class="col align-self-center">
             <div class="d-xl-flex justify-content-xl-center">
-              <div class="row justify-content-xl-center" style="padding-top: 30px; font-size: 32px; width: 100%; flex-wrap: nowrap">
-                <button class="btn btn-info btn-bevel btn-filter" id="btn-load"  type="button" style="display: flex; width: 40%; align-items: center; justify-content: center; margin-right: 10px; margin-bottom: 4px; font-size: 1vw;" onclick="javascript:load_template(event)">Load Template</button>
-                <button class="btn btn-primary btn-bevel btn-filter"             type="button" style="display: flex; width: 40%; align-items: center; justify-content: center; margin-right: 10px; margin-bottom: 4px; font-size: 1vw;" onclick="javascript:ice40hx8k_handler();">Simulate</button>
+              <div class="row btn-row">
+                <button class="btn btn-info btn-bevel btn-filter" id="btn-load"  type="button"  onclick="javascript:load_template(event)">Load Template</button>
+                <button class="btn btn-primary btn-bevel btn-filter"             type="button"  onclick="javascript:ice40hx8k_handler();">Simulate</button>
               </div>
             </div>
             <div class="d-xl-flex justify-content-xl-center">
-              <div class="row" style="align-items: center; justify-content: space-evenly; padding-top: 10px; font-size: 32px;">
-                <button class="btn btn-dark btn-bevel btn-filter"    type="button" style="vertical-align: middle; align-content: center; width: 6vw; height: calc(2vh+1vw); margin-right: 15px; margin-bottom: 6px; font-size: 1vw;" onclick="javascript:demo_handler()">Demo</button>
-                <button class="btn btn-warning btn-bevel btn-filter" type="button" style="vertical-align: middle; align-content: center; width: 6vw; height: calc(2vh+1vw); margin-right: 15px; margin-bottom: 6px; font-size: 1vw;" onclick="javascript:stop_handler()">Freeze</button>
-                <button class="btn btn-danger btn-bevel btn-filter" type="button" style="vertical-align: middle; align-content: center; width: 6vw; height: calc(2vh+1vw); margin-right: 15px; margin-bottom: 6px; font-size: 1vw;" onclick="javascript:reset_handler()">Stop</button>
+              <div class="row btn-row">
+                <button class="btn btn-dark btn-bevel btn-filter"    type="button" onclick="javascript:demo_handler()">Demo</button>
+                <button class="btn btn-warning btn-bevel btn-filter" type="button" onclick="javascript:stop_handler()">Freeze</button>
+                <button class="btn btn-danger btn-bevel btn-filter" type="button" onclick="javascript:reset_handler()">Stop</button>
               </div>
             </div>
             <div class="d-xl-flex justify-content-xl-center">
-              <div class="row justify-content-xl-center" style="padding-top: 10px;font-size: 32px;padding-bottom: 20px;width: 95%;height:max-content;">
-                <style>
-                  .lowerbtn {
-                    color: var(--display-4-color); 
-                    border: 1px solid var(--display-4-color); 
-                    width: 45%; 
-                    height: calc(2vh+1vw); 
-                    margin-right: 15px; 
-                    margin-bottom: 6px; 
-                    font-size: 0.9vw;
-                    white-space: nowrap;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                  }
-                </style>
+              <div class="btn-row row justify-content-xl-center">
                 <button class="btn btn-bevel btn-filter lowerbtn" id="switchsim" type="button" onclick="javascript:switchWorkspaceSim()">Workspace Simulation</button>
                 <button class="btn btn-bevel btn-filter lowerbtn" type="button" onclick="javascript:openHDLwave();">Verify Design</button>
               </div>
             </div>
           </div>
         </div>
-        <div id="editor-workspace" style="min-width: 20%; max-width: 65%; width: 65%; height: 100%; display: flex; flex-direction: row; align-items: center;">
+        <div id="editor-workspace">
           <div style="width: 100%; height: 100%; display: flex; flex-direction: column;">
             <div id="editor-tab-workspace-header">
                 <div class="editor-tab-workspace" id="editor-tab-workspace-add"><label class="tab-label-workspace" id="wksp-tab-add">+</label></div>


### PR DESCRIPTION
This is the result of a lot of changes to the CSS and style tags of index.html. Many style tags were moved from the html file to index.css. The look and feel and layout of the page was largely left untouched but all of the text was modified to have a minimum font size. Primarily how the ice board and the editor workspace was modified to better adjust to different screen sizes and ratios (E.g. the page now works well in split screen and kinda works on mobile devices). I somewhat accidentally auto formatted theme.css so many changes in that file are just formatting. 

I know that this is a really big merge so I would be fine breaking it in to smaller parts if you'd like. I especially think that the updates to the ice board/editor workspace layout are the best part of this and could merge them separately if there are problems with this mr.  