### PR TITLE
remove variable width editor

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -543,7 +543,7 @@ body {
 
 #editor-workspace {
     min-width: 400px;
-    max-width: 100%;
+    max-width: 850px;
     flex: 1;
     display: flex;
     flex-direction: row;

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1179,22 +1179,6 @@ Apple screws everything up for everyone who tries to develop on its platforms */
     color: var(--tutorial-btn-hover);
 }
 
-#resize-editor {
-    height: 200px;
-    width: 10px;
-    cursor: w-resize;
-    background-color: transparent;
-    border-left: 3px solid var(--display-4-color);
-    transition: border 0.2s;
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
-}
-
-#resize-editor:hover {
-    border-left: 9px solid var(--display-4-color);
-}
-
-
 /* sorry not sorry */
 
 #nevergonnagiveyouup:hover {

--- a/assets/js/simulator_backend.js
+++ b/assets/js/simulator_backend.js
@@ -1006,7 +1006,6 @@ function display_info(sect) {
 
 window.onbeforeunload = function() {
     window.localStorage.evalboardtheme = document.getElementById("evalthemeselector").value;
-    window.localStorage.editor_width = $("#editor-workspace").width();
     localStorage.ace_options = JSON.stringify(editor.getOptions());
     if (localStorage.ice40DarkMode == "true")
         localStorage.ace_dark_theme = editor.getOption("theme");

--- a/assets/js/workspaces.js
+++ b/assets/js/workspaces.js
@@ -527,12 +527,6 @@ function switchTabHandler (e) {
 }
 
 window.onload = function () {
-	if (window.localStorage.editor_width) {
-		$("#editor-workspace").css("flex", "none")
-		$('#editor-workspace').width (window.localStorage.editor_width || '65%')
-		$('#outputview').width (window.localStorage.editor_width || '65%')
-	}
-	var last_page_x = $('#resize-editor').position().left;
 
 	window.addEventListener("mousewheel", codescroll, { passive: false })
 	// load_button.innerHTML = load_btn_text
@@ -754,14 +748,6 @@ window.onload = function () {
 	).on ('click', '#mainview > div,nav', () => {
 		if ($(".notifications").css("opacity") == "1") 
 			toggleNotifs(true);
-	}).on ('mousedown', '#resize-editor', e => {
-		e.preventDefault();
-		if (term) {
-			term.resize (parseInt ($("#editor-workspace").width() / 10.5), parseInt ($("#editor-workspace").height() / 22.5))
-        }
-		$(e.target).addClass ('dragging')
-		last_page_x = e.pageX
-		return false;
 	}).on ('click', '.module_check', e => {
 		var icon  = e.currentTarget;
 		var mod   = icon.parentNode.querySelector('label').innerHTML;
@@ -804,37 +790,7 @@ window.onload = function () {
 		localStorage.switchsim = 'workspace'
 		$('#switchsim')[0].innerHTML = 'Workspace Simulation'
 	}
-
-	$(document).mousemove (e => {
-		if ($('#resize-editor')[0].classList.contains ("dragging")) {
-			if (last_page_x == 0) { //first time adjusting the editor
-				last_page_x = $('#resize-editor').position().left;
-			}
-			if (e.pageX < last_page_x) {
-				// left
-				var diff = (last_page_x - e.pageX)*2;	//doubled to try to match width diff to fast cursor movement
-				$("#editor-workspace").width($("#editor-workspace").width() - diff)
-				$("#outputview").width($("#editor-workspace").width() - diff)
-			}
-			else {
-				// right - make sure not to drag it larger than the width of the window!
-				var diff = (e.pageX - last_page_x)*2;	//doubled to try to match width diff to fast cursor movement
-				if ($("#status-navbar").width() - $("#editor-workspace").width() - diff >= 700
-						|| ($("#status-navbar").width() < 1675 &&  $("#editor-workspace").width() + diff < 1600)) {
-					$("#editor-workspace").width($("#editor-workspace").width() + diff)
-					$("#outputview").width($("#editor-workspace").width() + diff)
-				}
-			}
-			last_page_x = e.pageX
-			$("#editor-workspace").css("flex", "none")
-		}
-	})
-
-	$(document).mouseup (e => {
-		$('#resize-editor').removeClass ('dragging')
-		return false;
-	})
-
+	
 	// When the simulator starts for the first time, load template and set up tabs:
 	promised_code = new Promise((resolve, reject) => {
 		try {

--- a/index.html
+++ b/index.html
@@ -715,7 +715,6 @@
                 View</button>
           </div>
         </div>
-        <div id="resize-editor" draggable="true"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Due to certain bugs (and issues with resizing the screen) the variable width editor never lived up to it's expectation. Now it's variable width but determined by the width of the screen instead of by configuration. Hopefully this will make it easier to use. 